### PR TITLE
Merge 1138 updates in

### DIFF
--- a/io_alamo_tools/__init__.py
+++ b/io_alamo_tools/__init__.py
@@ -168,6 +168,8 @@ class ALAMO_PT_materialPropertyPanel(bpy.types.Panel):
                                 layout.prop_search(material, "WaveTexture", bpy.data, "images")
                             elif property == 'DistortionTexture':
                                 layout.prop_search(material, "DistortionTexture", bpy.data, "images")
+                            elif property == 'SpecularTexture':
+                                layout.prop_search(material, "SpecularTexture", bpy.data, "images")
                             else:
                                 c.prop(material, property)
 
@@ -267,6 +269,7 @@ def register():
     bpy.types.Material.NormalDetailTexture = bpy.props.StringProperty(default='None')
     bpy.types.Material.NormalTexture = bpy.props.StringProperty(default='None')
     bpy.types.Material.GlossTexture = bpy.props.StringProperty(default='None')
+    bpy.types.Material.SpecularTexture = bpy.props.StringProperty(default='None')
     bpy.types.Material.WaveTexture = bpy.props.StringProperty(default='None')
     bpy.types.Material.DistortionTexture = bpy.props.StringProperty(default='None')
     bpy.types.Material.CloudTexture = bpy.props.StringProperty(default='None')
@@ -340,6 +343,7 @@ def unregister():
     bpy.types.Material.GlossTexture
     bpy.types.Material.WaveTexture
     bpy.types.Material.DistortionTexture
+    bpy.types.Material.SpecularTexture
     bpy.types.Material.CloudTexture
     bpy.types.Material.CloudNormalTexture
 

--- a/io_alamo_tools/armature.py
+++ b/io_alamo_tools/armature.py
@@ -1,0 +1,68 @@
+centers = []
+
+for object in bpy.context.selected_objects:
+    center = object.matrix_world @ (1 / 8 * sum((Vector(vector) for vector in object.bound_box), Vector())) 
+    object.location -= center
+    centers += [center]
+
+print(centers)
+
+import random
+
+index = 0
+
+for vector in centers:
+    print(str(index))
+    bone = bpy.data.armatures['Armature'].edit_bones.new(str(index))
+    bone.head = vector
+    bone.tail = vector + Vector((random.uniform(-1, 1), random.uniform(-1, 1), random.uniform(-1, 1))).normalized()
+    index += 1
+
+
+
+import random
+
+index = 0
+objects = []
+
+for object in bpy.context.selected_objects:
+    objects += [object]
+
+random.shuffle(objects)
+
+for object in objects:
+    constraint = object.constraints.new('CHILD_OF')
+    constraint.target = bpy.data.objects['Armature']
+    constraint.subtarget = str(index)
+    constraint.inverse_matrix = Matrix.Identity(4)
+    index += 1
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+for object in bpy.context.selected_objects:
+    for constraint in object.constraints:
+        constraint.inverse_matrix = Matrix.Identity(4)
+
+
+import random
+
+index = 0
+objects = []
+for object in bpy.context.selected_objects:
+    objects += [object]
+random.shuffle(objects)
+for object in objects:
+    for constraint in object.constraints[:]:
+        constraint.subtarget = str(index)
+    index += 1

--- a/io_alamo_tools/export_ala.py
+++ b/io_alamo_tools/export_ala.py
@@ -383,9 +383,11 @@ def create_visibility_chunk(armature, bone):
     dataExists = False
     for curve in armature.animation_data.action.fcurves:
         # by spliting and comparing the data path we know which bone has rotation/location keyframes
-        if curve.data_path.split('"')[1] == bone.name and curve.data_path.split('"')[2] == '].proxyIsHiddenAnimation':
-            dataExists = True
-            break
+        parts = curve.data_path.split('"');
+        if (parts[2] == '].proxyIsHiddenAnimation'):
+            if parts[1] == bone.name or (bone.parent != None and bone.parent.name == parts[1]):
+                dataExists = True
+                break
 
     if not dataExists:
         return b''
@@ -394,13 +396,19 @@ def create_visibility_chunk(armature, bone):
     binary = ''
 
     pose = armature.pose.bones[bone.name]
+    
+    parentPose = {}
+    if bone.parent != None:
+        parentPose = armature.pose.bones[bone.parent.name]
+    else:
+        parentPose = None
 
     action = utils.getCurrentAction()
     animLength = action.AnimationEndFrame
 
     scene.frame_set(0)
     while scene.frame_current <= animLength:
-        if pose.proxyIsHiddenAnimation == True:
+        if pose.proxyIsHiddenAnimation == True or (parentPose != None and parentPose.proxyIsHiddenAnimation):
             binary += '0'
         else:
             binary += '1'

--- a/io_alamo_tools/export_alo.py
+++ b/io_alamo_tools/export_alo.py
@@ -1374,11 +1374,6 @@ class ALO_Exporter(bpy.types.Operator):
                     raise RuntimeError('Face number exceeds uShort max on object: ' + object.name + ' split mesh into multiple objects')
                     return True
 
-        def checkAutosmooth(mesh_list):  #prints a warning if Autosmooth is used
-            for object in mesh_list:
-                if object.data.use_auto_smooth:
-                    print('Warning: ' + object.name + ' uses autosmooth, ingame shading might not match blender, use edgesplit instead')
-
         def checkTranslation(mesh_list): #prints warning when translation is not default
             for object in mesh_list:
                 if object.location != mathutils.Vector((0.0, 0.0, 0.0)) or object.rotation_euler != mathutils.Euler((0.0, 0.0, 0.0), 'XYZ') or object.scale != mathutils.Vector((1.0, 1.0, 1.0)):
@@ -1470,7 +1465,6 @@ class ALO_Exporter(bpy.types.Operator):
             checkShadowMesh(mesh_list)
         checkUV(mesh_list)
         checkFaceNumber(mesh_list)
-        checkAutosmooth(mesh_list)
         checkTranslation(mesh_list)
         checkTranslationArmature()
         checkInvalidArmatureModifier(mesh_list)

--- a/io_alamo_tools/export_alo.py
+++ b/io_alamo_tools/export_alo.py
@@ -503,31 +503,35 @@ class ALO_Exporter(bpy.types.Operator):
 
             # list of all faces using the current material
             per_face_vertex_id = {}
-
             vertices = []
             face_indices = []
-
+            vertex_index_map = {}
             alo_index = 0
+            
             for face in bm.faces:
                 indexArray = {}
+                
                 for vert in face.verts:
                     vertex = vertexData()
+                    
                     vertex.co = vert.co
                     vertex.normal = face.normal
+                    key = (vert.index, face.normal.x, face.normal.y, face.normal.z)
+                    if key in vertex_index_map:
+                        indexArray[vert.index] = vertex_index_map[key]
+                        face_indices.append(vertex_index_map[key])
+                    else:
+                        vertex_index_map[key] = alo_index            
+                        vertex.uv =  mathutils.Vector((0, 0))
+                        meshVertex = mesh.vertices[vert.index]
+                        vertex.bone_index = getMaxWeightGroupIndex(meshVertex)
+                        if(vertex.bone_index == None):
+                            vertex.bone_index = 0
+                        vertices.append(vertex)
+                        face_indices.append(alo_index)
+                        indexArray[vert.index] = alo_index
+                        alo_index += 1
 
-                    vertex.uv =  mathutils.Vector((0, 0))
-
-                    meshVertex = mesh.vertices[vert.index]
-                    vertex.bone_index = getMaxWeightGroupIndex(meshVertex)
-                    if(vertex.bone_index == None):
-                        vertex.bone_index = 0
-
-
-                    vertices.append(vertex)
-                    face_indices.append(alo_index)
-
-                    indexArray[vert.index] = alo_index
-                    alo_index += 1
                 per_face_vertex_id[face.index] = indexArray
 
 

--- a/io_alamo_tools/export_alo.py
+++ b/io_alamo_tools/export_alo.py
@@ -449,6 +449,7 @@ class ALO_Exporter(bpy.types.Operator):
             uv_layer = mesh.uv_layers.active.data
             loop_to_alo_index = {}   #dictionary that maps blender vertex indices to the corresponding alo index
                                         #only smooth shaded faces are saved here, as flat shaded faces need duplicate vertices anyway
+            vertex_index_map = {}
 
             alo_index = 0
             for face in faces:
@@ -457,6 +458,8 @@ class ALO_Exporter(bpy.types.Operator):
                     vert = loop.vert
                     store_vertex = True
 
+                    key = (vert.index, face.normal.x, face.normal.y, face.normal.z, uv_layer[loop.index].uv.x, uv_layer[loop.index].uv.y)
+                    
                     if face.smooth:
                         for adjacent_loop in vert.link_loops:
                             if adjacent_loop != loop and uv_layer[loop.index].uv == uv_layer[adjacent_loop.index].uv:
@@ -465,7 +468,9 @@ class ALO_Exporter(bpy.types.Operator):
                                     face_indices.append(loop_to_alo_index[adjacent_loop.index])
                                     store_vertex = False
                                     break
-
+                    elif key in vertex_index_map:
+                        face_indices.append(vertex_index_map[key])
+                        store_vertex = False
 
                     if store_vertex:
                         vertex = vertexData()
@@ -488,6 +493,8 @@ class ALO_Exporter(bpy.types.Operator):
 
                         if face.smooth:
                             loop_to_alo_index[loop.index] = alo_index
+                        else:
+                            vertex_index_map[key] = alo_index     
 
                         vertex.face_index = face.index
 

--- a/io_alamo_tools/export_alo.py
+++ b/io_alamo_tools/export_alo.py
@@ -535,61 +535,53 @@ class ALO_Exporter(bpy.types.Operator):
                 face1 = edge.link_faces[0]
                 face2 = edge.link_faces[1]
 
-                f1v1 = per_face_vertex_id[face1.index][edge.verts[0].index]
-                f1v2 = per_face_vertex_id[face1.index][edge.verts[1].index]
+                if face1.normal != face2.normal:
+                    f1v1 = per_face_vertex_id[face1.index][edge.verts[0].index]
+                    f1v2 = per_face_vertex_id[face1.index][edge.verts[1].index]
 
-                f2v1 = per_face_vertex_id[face2.index][edge.verts[0].index]
-                f2v2 = per_face_vertex_id[face2.index][edge.verts[1].index]
+                    f2v1 = per_face_vertex_id[face2.index][edge.verts[0].index]
+                    f2v2 = per_face_vertex_id[face2.index][edge.verts[1].index]
 
-                mid1 = mathutils.Vector((0, 0, 0))
-                for vert in face1.verts:
-                    mid1 += vert.co
-                mid1 /= 3
+                    mid1 = mathutils.Vector((0, 0, 0))
+                    for vert in face1.verts:
+                        mid1 += vert.co
+                    mid1 /= 3
 
-                mid2 = mathutils.Vector((0, 0, 0))
-                for vert in face2.verts:
-                    mid2 += vert.co
-                mid2 /= 3
+                    mid2 = mathutils.Vector((0, 0, 0))
+                    for vert in face2.verts:
+                        mid2 += vert.co
+                    mid2 /= 3
 
 
-                face1v1 = edge.verts[0].co * 0.75 + mid1 * 0.25
-                face1v2 = edge.verts[1].co * 0.75 + mid1 * 0.25
-                face2v1 = edge.verts[0].co * 0.75 + mid2 * 0.25
-                face2v2 = edge.verts[1].co * 0.75 + mid2 * 0.25
+                    face1v1 = edge.verts[0].co * 0.75 + mid1 * 0.25
+                    face1v2 = edge.verts[1].co * 0.75 + mid1 * 0.25
+                    face2v1 = edge.verts[0].co * 0.75 + mid2 * 0.25
+                    face2v2 = edge.verts[1].co * 0.75 + mid2 * 0.25
 
-                out = face1.normal + face2.normal
+                    out = face1.normal + face2.normal
 
-                #first face
-                edge1 = face1v1 - face2v1
-                edge2 = face1v2 - face2v1
+                    #first face
+                    edge1 = face1v1 - face2v1
+                    edge2 = face1v2 - face2v1
 
-                cross = mathutils.Vector.cross(edge1, edge2)
-                dot = mathutils.Vector.dot(out, cross)
+                    cross = mathutils.Vector.cross(edge1, edge2)
+                    dot = mathutils.Vector.dot(out, cross)
 
-                if dot < 0:
-                    face_indices.append(f1v1)
-                    face_indices.append(f2v1)
-                    face_indices.append(f1v2)
-                else:
-                    face_indices.append(f1v1)
-                    face_indices.append(f1v2)
-                    face_indices.append(f2v1)
-
-                #second face
-                edge1 = face1v1 - face2v1
-                edge2 = face1v2 - face2v1
-
-                cross = mathutils.Vector.cross(edge1, edge2)
-                dot = mathutils.Vector.dot(out, cross)
-
-                if dot < 0:
-                    face_indices.append(f2v2)
-                    face_indices.append(f1v2)
-                    face_indices.append(f2v1)
-                else:
-                    face_indices.append(f2v2)
-                    face_indices.append(f2v1)
-                    face_indices.append(f1v2)
+                    if dot < 0:
+                        # print("dot " + str(dot))
+                        face_indices.append(f1v1)
+                        face_indices.append(f2v1)
+                        face_indices.append(f1v2)
+                        face_indices.append(f2v2)
+                        face_indices.append(f1v2)
+                        face_indices.append(f2v1)
+                    else:
+                        face_indices.append(f1v1)
+                        face_indices.append(f1v2)
+                        face_indices.append(f2v1)
+                        face_indices.append(f2v2)
+                        face_indices.append(f2v1)
+                        face_indices.append(f1v2)
 
             return [vertices, face_indices]
 

--- a/io_alamo_tools/import_ala.py
+++ b/io_alamo_tools/import_ala.py
@@ -281,7 +281,7 @@ def create_animation(data):
     scene = bpy.context.scene
     scene.frame_start = 0
     scene.frame_end = data.num_frames-1
-    scene.render.fps = data.fps
+    scene.render.fps = int(data.fps)
     scene.frame_set(0)
 
     utils.setModeToObject()

--- a/io_alamo_tools/import_alo.py
+++ b/io_alamo_tools/import_alo.py
@@ -415,25 +415,16 @@ class ALO_Importer(bpy.types.Operator):
             return animation_mapping
 
         def set_up_textures(material):
-
             material.use_nodes = True
             nt = material.node_tree
             nodes = nt.nodes
             links = nt.links
-
-            #clean up
             while(nodes): nodes.remove(nodes[0])
-
             output  = nodes.new("ShaderNodeOutputMaterial")
             bsdf = nodes.new("ShaderNodeBsdfPrincipled")
-
             base_image_node = nodes.new("ShaderNodeTexImage")
             invert_color_node = nodes.new("ShaderNodeInvert")
             normal_image_node = nodes.new("ShaderNodeTexImage")
-
-            normal_map_node = nodes.new("ShaderNodeNormalMap")
-            normal_map_node.space = 'TANGENT'
-
             if material.BaseTexture != 'None':
                 links.new(output.inputs['Surface'], bsdf.outputs['BSDF'])
                 links.new(bsdf.inputs['Base Color'], base_image_node.outputs['Color'])
@@ -443,24 +434,20 @@ class ALO_Importer(bpy.types.Operator):
                     diffuse_texture = bpy.data.images[material.BaseTexture]
                     base_image_node.image = diffuse_texture
             if material.NormalTexture != 'None':
+                normal_map_node = nodes.new("ShaderNodeNormalMap")
+                normal_map_node.space = 'TANGENT'
                 links.new(normal_image_node.outputs['Color'], normal_map_node.inputs['Color'])
                 links.new(normal_map_node.outputs['Normal'], bsdf.inputs['Normal'])
                 if material.NormalTexture in bpy.data.images:
                     normal_texture = bpy.data.images[material.NormalTexture]
                     normal_image_node.image = normal_texture
-                    normal_image_node.image.colorspace_settings.name = 'Raw'
-            # distribute nodes along the x axis
-            for index, node in enumerate((base_image_node, bsdf, output)):
-                node.location.x = 200.0 * index
-
-            normal_map_node.location = bsdf.location
-            normal_map_node.location.y += 300.0
-
-            output.location.x += 200.0
-            bsdf.location.x += 200.0
-
-            normal_image_node.location = base_image_node.location
-            normal_image_node.location.y += 300.0
+                normal_image_node.location.y = -400
+                normal_map_node.location.x = normal_image_node.location.x + normal_image_node.width + 100
+                normal_map_node.location.y = -400
+            invert_color_node.location.x = base_image_node.location.x + base_image_node.width + 100
+            invert_color_node.location.y = -200
+            bsdf.location.x = invert_color_node.location.x + invert_color_node.width + 100
+            output.location.x = bsdf.location.x + bsdf.width + 100
 
         def create_object(currentMesh):
             global mesh

--- a/io_alamo_tools/import_alo.py
+++ b/io_alamo_tools/import_alo.py
@@ -714,7 +714,7 @@ class ALO_Importer(bpy.types.Operator):
                         #hide smaller LODS
                         counter = 0
                         while(counter < lodCounter-1):
-                            bpy.data.objects[object.name[:-1] + str(counter)].hide_viewport = True
+                            bpy.data.objects[object.name[:-1] + str(counter)].hide_set(True)
                             counter += 1
 
             #hide object if its a shadow or a collision
@@ -723,13 +723,13 @@ class ALO_Importer(bpy.types.Operator):
                     if len(object.material_slots) != 0:
                         shader = object.material_slots[0].material.shaderList.shaderList
                         if(shader == 'MeshCollision.fx' or shader == 'RSkinShadowVolume.fx' or shader == 'MeshShadowVolume.fx'):
-                            object.hide_viewport = True
+                            object.hide_set(True)
 
             #hide objects that are set to not visible
             for object in bpy.data.objects:
                 if (object.type == 'MESH'):
                     if object.Hidden == True:
-                        object.hide_viewport = True
+                        object.hide_set(True)
 
         def deleteRoot():
             armature = utils.findArmature()

--- a/io_alamo_tools/import_alo.py
+++ b/io_alamo_tools/import_alo.py
@@ -923,7 +923,9 @@ class ALO_Importer(bpy.types.Operator):
                     createdArmature.parent = armature
                     createdArmature.parent_bone = self.parentName
                     createdArmature.parent_type = 'BONE'
-
+        for object in bpy.data.objects:
+            for constraint in object.constraints:
+                constraint.inverse_matrix = mathutils.Matrix.Identity(4)
         return {'FINISHED'}            # this lets blender know the operator finished successfully.
 
     def invoke(self, context, event):

--- a/io_alamo_tools/import_alo.py
+++ b/io_alamo_tools/import_alo.py
@@ -289,7 +289,7 @@ class ALO_Importer(bpy.types.Operator):
                     face.material_index = subMeshCounter
 
             # create UVs
-            createUVLayer("MainUV", UVs)
+            createUVLayer("UVMap", UVs)
             assign_vertex_groups(animationMapping, currentMesh)
 
             return mesh
@@ -714,24 +714,6 @@ class ALO_Importer(bpy.types.Operator):
             file.seek(1, 1)  # skip end byte of name
             return string
 
-        def hideObject(object):
-
-            #set correct area type via context overwrite
-            context_override = bpy.context.copy()
-            area = None
-            for window in bpy.context.window_manager.windows:
-                screen = window.screen
-                for a in screen.areas:
-                    if a.type == 'VIEW_3D':
-                        area = a
-                        break
-
-            context_override['area'] = area
-
-            bpy.ops.object.select_all(context_override, action='DESELECT')
-            object.select_set(True)
-            bpy.ops.object.hide_view_set(context_override)
-
         def hideLODs():
             #hides all but the most detailed LOD in Blender
             for object in bpy.data.objects:
@@ -745,7 +727,7 @@ class ALO_Importer(bpy.types.Operator):
                         #hide smaller LODS
                         counter = 0
                         while(counter < lodCounter-1):
-                            hideObject(bpy.data.objects[object.name[:-1] + str(counter)])
+                            bpy.data.objects[object.name[:-1] + str(counter)].hide_viewport = True
                             counter += 1
 
             #hide object if its a shadow or a collision
@@ -754,13 +736,13 @@ class ALO_Importer(bpy.types.Operator):
                     if len(object.material_slots) != 0:
                         shader = object.material_slots[0].material.shaderList.shaderList
                         if(shader == 'MeshCollision.fx' or shader == 'RSkinShadowVolume.fx' or shader == 'MeshShadowVolume.fx'):
-                            hideObject(object)
+                            object.hide_viewport = True
 
             #hide objects that are set to not visible
             for object in bpy.data.objects:
                 if (object.type == 'MESH'):
                     if object.Hidden == True:
-                        hideObject(object)
+                        object.hide_viewport = True
 
         def deleteRoot():
             armature = utils.findArmature()

--- a/io_alamo_tools/settings.py
+++ b/io_alamo_tools/settings.py
@@ -1,44 +1,48 @@
 import bpy
 
 material_parameter_dict = {
-    "alDefault.fx": [""],
-    "BatchMeshAlpha.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
-    "BatchMeshGloss.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
-    "Grass.fx": ["Emissive", "Diffuse", "Diffuse1", "BendScale", "BaseTexture"],
-    "MeshAdditive.fx": ["BaseTexture", "UVScrollRate", "Color"],
-    "MeshAlpha.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
-    "MeshAlphaScroll.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
-    "MeshBumpColorize.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "Colorization", "UVOffset",
-                            "BaseTexture", "NormalTexture"],
-    "MeshBumpColorizeVertex.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "Colorization", "UVOffset",
-                            "BaseTexture", "NormalTexture"],
-    "MeshBumpColorizeDetail.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "Colorization", "UVOffset",
-                            "BaseTexture", "DetailTexture", "NormalTexture", "MappingScale", "BlendSharpness", "NormalDetailTexture"],
-    "MeshBumpLight.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "Colorization", "UVOffset",
-                         "BaseTexture", "NormalTexture"],
-    "MeshCollision.fx": ["Color"],
-    "MeshGloss.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
-    "MeshGlossColorize.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture", "GlossTexture"],
-    "MeshShadowVolume.fx": ["DebugColor"],
-    "MeshShield.fx": ["Color", "EdgeBrightness", "BaseUVScale", "WaveUVScale", "DistortUVScale",
-                      "BaseUVScrollRate",
-                      "WaveUVScrollRate", "DistortUVScrollRate", "BaseTexture", "WaveTexture", "DistortionTexture"],
-    "Nebula.fx": ["BaseTexture", "UVScrollRate", "DistortionScale", "SFreq", "TFreq"],
-    "Planet.fx": ["Emissive", "Diffuse", "Specular", "Atmosphere", "CityColor", "AtmospherePower",
-                  "CloudScrollRate", "BaseTexture", "NormalTexture", "CloudTexture", "CloudNormalTexture"],
-    "RSkinAdditive.fx": ["BaseTexture", "UVScrollRate", "Color"],
-    "RSkinAlpha.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
-    "RSkinBumpColorize.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "Colorization", "UVOffset",
-                             "BaseTexture", "NormalTexture"],
-    "RSkinGloss.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
-    "RSkinGlossColorize.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "Colorization", "BaseTexture",
-                              "GlossTexture"],
-    "RSkinShadowVolume.fx": ["DebugColor"],
-    "Skydome.fx": ["Emissive", "CloudScrollRate", "CloudScale", "BaseTexture", "CloudTexture"],
-    "TerrainMeshBump.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture", "NormalTexture"],
-    "TerrainMeshGloss.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
-    "Tree.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BendScale", "BaseTexture", "NormalTexture"],
-    "LightProxy.fx": ["Diffuse"]
+	"alDefault.fx": [""],
+	"BatchMeshAlpha.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
+	"BatchMeshGloss.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
+	"Grass.fx": ["Emissive", "Diffuse", "Diffuse1", "BendScale", "BaseTexture"],
+	"MeshAdditive.fx": ["BaseTexture", "UVScrollRate", "Color"],
+	"MeshAlpha.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
+	"MeshAlphaScroll.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
+	"MeshBumpColorize.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "Colorization", "UVOffset",
+							"BaseTexture", "NormalTexture"],
+	"MeshBumpColorizeVertex.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "Colorization", "UVOffset",
+							"BaseTexture", "NormalTexture"],
+	"MeshBumpColorizeDetail.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "Colorization", "UVOffset",
+							"BaseTexture", "DetailTexture", "NormalTexture", "MappingScale", "BlendSharpness", "NormalDetailTexture"],
+	"MeshBumpLight.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "Colorization", "UVOffset",
+						 "BaseTexture", "NormalTexture"],
+	"MeshCollision.fx": ["Color"],
+	"MeshGloss.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
+	"MeshGlossColorize.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture", "GlossTexture"],
+	"MeshShadowVolume.fx": ["DebugColor"],
+	"MeshShield.fx": ["Color", "EdgeBrightness", "BaseUVScale", "WaveUVScale", "DistortUVScale",
+					  "BaseUVScrollRate",
+					  "WaveUVScrollRate", "DistortUVScrollRate", "BaseTexture", "WaveTexture", "DistortionTexture"],
+	"Nebula.fx": ["BaseTexture", "UVScrollRate", "DistortionScale", "SFreq", "TFreq"],
+	"Planet.fx": ["Emissive", "Diffuse", "Specular", "Atmosphere", "CityColor", "AtmospherePower",
+				  "CloudScrollRate", "BaseTexture", "NormalTexture", "CloudTexture", "CloudNormalTexture"],
+	"RSkinAdditive.fx": ["BaseTexture", "UVScrollRate", "Color"],
+	"RSkinAlpha.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
+	"RSkinBumpColorize.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "Colorization", "UVOffset",
+							 "BaseTexture", "NormalTexture"],
+	"RSkinGloss.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
+	"RSkinGlossColorize.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "Colorization", "BaseTexture",
+							  "GlossTexture"],
+	"RSkinShadowVolume.fx": ["DebugColor"],
+	"Skydome.fx": ["Emissive", "CloudScrollRate", "CloudScale", "BaseTexture", "CloudTexture"],
+	"TerrainMeshBump.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture", "NormalTexture"],
+	"TerrainMeshGloss.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
+	"Tree.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BendScale", "BaseTexture", "NormalTexture"],
+	"LightProxy.fx": ["Diffuse"],
+	"MeshAlphaGloss.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "BaseTexture"],
+	"MeshBumpSpecGlowColorize.fx": ["Emissive", "Diffuse", "Colorization", "UVOffset", "BaseTexture", "NormalTexture", "SpecularTexture"],
+	"MeshBumpReflectColorize.fx": ["Emissive", "Diffuse", "Specular", "Shininess", "Colorization", "UVOffset",
+							"BaseTexture", "NormalTexture"]
 }
 
 vertex_format_dict = {
@@ -70,12 +74,15 @@ vertex_format_dict = {
     "TerrainMeshBumb.fx"    : "alD3dVertNU2U3U3",
     "TerrainMeshGloss.fx"   : "alD3dVertNU2",
     "Tree.fx"               : "alD3dVertNU2",
-    "LightProxy.fx"         : "alD3dVertNU2"
+    "LightProxy.fx"         : "alD3dVertNU2",
+    "MeshAlphaGloss.fx"     : "alD3dVertNU2",
+    "MeshBumpSpecGlowColorize.fx" : "alD3dVertNU2C",
+    "MeshBumpReflectColorize.fx"  : "alD3dVertNU2U3U3"
 }
 
 billboard_array = {"Disable":0, "Parallel":1, "Face":2, "ZAxis View": 3, "ZAxis Light":4, "ZAxis Wind":5, "Sunlight Glow":6, "Sun":7}
 
-bumpMappingList = ['MeshBumpColorize.fx', 'MeshBumpColorizeVertex.fx', 'MeshBumpColorizeDetail.fx', "MeshBumpLight.fx", "Planet.fx", "RSkinBumpColorize.fx", "TerrainMeshBump.fx", "Tree.fx"]
+bumpMappingList = ['MeshBumpColorize.fx', 'MeshBumpReflectColorize.fx', 'MeshBumpColorizeVertex.fx', 'MeshBumpColorizeDetail.fx', "MeshBumpLight.fx", "Planet.fx", "RSkinBumpColorize.fx", "TerrainMeshBump.fx", "Tree.fx"]
 
 rotation_curve_name = ['].rotation_quaternion', '].rotation_euler']
 


### PR DESCRIPTION
From 1138:

But I did not try to merge because cannot vouch for all my changes, looking at the diff:

- add SpecularTexture texture support;
- weird thing on proxyIsHiddenAnimation don't remember why;
- add a check box for shadow mesh check on export (mainly for speeding up export);
- vertex optimisation;
- fps cast (that was already fix by others);
- UVMap default name;
- reorganise blender shader with a inverse alpha node for dds;
- clear inverse on import;
- add some shader support (MeshAlphaGloss, MeshBumpSpecGlowColorize, MeshBumpReflectColorize, MeshBumpReflectColorize).